### PR TITLE
DEVOPS-1952: convert responses to hashie objects

### DIFF
--- a/lib/aha-api/connection.rb
+++ b/lib/aha-api/connection.rb
@@ -21,8 +21,12 @@ module AhaApi
       # TODO: Don't build on every request
       Faraday.new(options) do |builder|
         builder.request :json
-        builder.response :json if accept == 'application/json'
         builder.request(:authorization, :basic, login, password)
+
+        if accept == 'application/json'
+          builder.response :mashify
+          builder.response :json
+        end
 
         builder.use Faraday::FollowRedirects::Middleware
         builder.use Faraday::Mashify::Middleware


### PR DESCRIPTION
Alright, one more fix: The responses are not being converted to Hashie objects as they previously were, but rather plain hashes. This is causing a problem with the PivotalTracker integration: https://aha-labs-inc.sentry.io/issues/4279740678/?project=139823

Previous behavior:

```
3.1.3 :002 > AhaApi.new(domain: 'mt-baker').search_integration_fields('7145982403770750106', 'key', 'ENGTEAM-2', access_token: '9f34fa046c6e0c3329cf69b9e585ed
95cc105282436df87db6431f14897bc48a').class
 => Hashie::Mash 
```

Current behavior:

```
3.1.3 :002 > AhaApi.new(domain: 'mt-baker').search_integration_fields('7145982403770750106', 'key', 'ENGTEAM-2', access_token: '9f34fa046c6e0c3329cf69b9e585ed
95cc105282436df87db6431f14897bc48a').class
 => Hash 
```

This branch:

```
3.1.3 :003 > AhaApi.new(domain: 'mt-baker').search_integration_fields('7145982403770750106', 'key', 'ENGTEAM-2', access_token: '9f34fa046c6e0c3329cf69b9e585ed
95cc105282436df87db6431f14897bc48a').class
 => Hashie::Mash 
```